### PR TITLE
Clawdapus optional integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,19 +179,24 @@ workgraph skill diff workgraph-manual --json
 
 ### Optional Clawdapus integration
 
-Import the official Clawdapus skill document into your workspace only when you
-want it:
+List supported optional integrations:
 
 ```bash
-workgraph integration clawdapus \
+workgraph integration list --json
+```
+
+Install by integration ID (extensible pattern for future integrations):
+
+```bash
+workgraph integration install clawdapus \
   --actor agent-architect \
   --json
 ```
 
-Refresh from upstream later:
+Refresh from upstream later (or use the `integration clawdapus` alias):
 
 ```bash
-workgraph integration clawdapus --force --actor agent-architect --json
+workgraph integration install clawdapus --force --actor agent-architect --json
 ```
 
 ## Legacy memory stacks vs Workgraph primitives

--- a/src/clawdapus.test.ts
+++ b/src/clawdapus.test.ts
@@ -31,6 +31,7 @@ describe('clawdapus optional integration', () => {
       },
     });
 
+    expect(result.provider).toBe('clawdapus');
     expect(result.replacedExisting).toBe(false);
     expect(result.skill.path).toBe('skills/clawdapus/SKILL.md');
     expect(result.skill.fields.distribution).toBe('clawdapus-optional-integration');

--- a/src/clawdapus.ts
+++ b/src/clawdapus.ts
@@ -1,109 +1,37 @@
-import { loadSkill, writeSkill, type WriteSkillOptions } from './skill.js';
-import type { PrimitiveInstance } from './types.js';
+import {
+  fetchSkillMarkdownFromUrl,
+  installSkillIntegration,
+  type InstallSkillIntegrationOptions,
+  type InstallSkillIntegrationResult,
+  type SkillIntegrationProvider,
+} from './integration-core.js';
 
 export const DEFAULT_CLAWDAPUS_SKILL_URL =
   'https://raw.githubusercontent.com/mostlydev/clawdapus/master/skills/clawdapus/SKILL.md';
 
-export interface InstallClawdapusSkillOptions {
-  actor: string;
-  owner?: string;
-  title?: string;
-  sourceUrl?: string;
-  force?: boolean;
-  status?: WriteSkillOptions['status'];
-  tags?: string[];
-  fetchSkillMarkdown?: (sourceUrl: string) => Promise<string>;
-}
+export const CLAWDAPUS_INTEGRATION_PROVIDER: SkillIntegrationProvider = {
+  id: 'clawdapus',
+  defaultTitle: 'clawdapus',
+  defaultSourceUrl: DEFAULT_CLAWDAPUS_SKILL_URL,
+  distribution: 'clawdapus-optional-integration',
+  defaultTags: ['clawdapus'],
+  userAgent: '@versatly/workgraph clawdapus-optional-integration',
+};
 
-export interface InstallClawdapusSkillResult {
-  skill: PrimitiveInstance;
-  sourceUrl: string;
-  importedAt: string;
-  replacedExisting: boolean;
-}
+export type InstallClawdapusSkillOptions = InstallSkillIntegrationOptions;
+export type InstallClawdapusSkillResult = InstallSkillIntegrationResult;
 
 export async function installClawdapusSkill(
   workspacePath: string,
   options: InstallClawdapusSkillOptions,
 ): Promise<InstallClawdapusSkillResult> {
-  const actor = options.actor.trim();
-  if (!actor) {
-    throw new Error('Clawdapus integration requires a non-empty actor.');
-  }
-
-  const title = options.title?.trim() || 'clawdapus';
-  const sourceUrl = options.sourceUrl?.trim() || DEFAULT_CLAWDAPUS_SKILL_URL;
-  const existing = loadSkillIfExists(workspacePath, title);
-  if (existing && !options.force) {
-    throw new Error(
-      `Skill "${title}" already exists at ${existing.path}. Use --force to refresh it from source.`,
-    );
-  }
-
-  const fetchSkillMarkdown = options.fetchSkillMarkdown ?? fetchClawdapusSkillMarkdown;
-  const markdown = await fetchSkillMarkdown(sourceUrl);
-  if (!markdown.trim()) {
-    throw new Error(`Downloaded Clawdapus skill from ${sourceUrl} is empty.`);
-  }
-
-  const skill = writeSkill(workspacePath, title, markdown, actor, {
-    owner: options.owner ?? actor,
-    status: options.status,
-    distribution: 'clawdapus-optional-integration',
-    tags: mergeTags(options.tags),
-  });
-
-  return {
-    skill,
-    sourceUrl,
-    importedAt: new Date().toISOString(),
-    replacedExisting: existing !== null,
-  };
+  return installSkillIntegration(
+    workspacePath,
+    CLAWDAPUS_INTEGRATION_PROVIDER,
+    options,
+  );
 }
 
 export async function fetchClawdapusSkillMarkdown(sourceUrl: string): Promise<string> {
-  let response: Response;
-  try {
-    response = await fetch(sourceUrl, {
-      headers: {
-        'user-agent': '@versatly/workgraph clawdapus-optional-integration',
-      },
-    });
-  } catch (error) {
-    throw new Error(
-      `Failed to download Clawdapus skill from ${sourceUrl}: ${errorMessage(error)}`,
-    );
-  }
-
-  if (!response.ok) {
-    throw new Error(
-      `Failed to download Clawdapus skill from ${sourceUrl}: HTTP ${response.status} ${response.statusText}`,
-    );
-  }
-  return response.text();
-}
-
-function loadSkillIfExists(workspacePath: string, skillRef: string): PrimitiveInstance | null {
-  try {
-    return loadSkill(workspacePath, skillRef);
-  } catch (error) {
-    const message = errorMessage(error);
-    if (message.startsWith('Skill not found:')) {
-      return null;
-    }
-    throw error;
-  }
-}
-
-function mergeTags(tags: string[] | undefined): string[] {
-  const merged = new Set<string>(['clawdapus', 'optional-integration']);
-  for (const tag of tags ?? []) {
-    const normalized = tag.trim();
-    if (normalized) merged.add(normalized);
-  }
-  return [...merged];
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+  return fetchSkillMarkdownFromUrl(sourceUrl, CLAWDAPUS_INTEGRATION_PROVIDER.userAgent);
 }

--- a/src/cli-compat.test.ts
+++ b/src/cli-compat.test.ts
@@ -80,6 +80,22 @@ describe('CLI compatibility smoke', () => {
         '--json',
       ]);
       expect(skillLoad.ok).toBe(true);
+
+      const integrationList = runCli([
+        'integration', 'list',
+        '-w', workspacePath,
+        '--json',
+      ]);
+      expect(integrationList.ok).toBe(true);
+
+      const integrationInstall = runCli([
+        'integration', 'install', 'clawdapus',
+        '-w', workspacePath,
+        '--actor', 'agent-compat',
+        '--source-url', 'data:text/plain,%23%20Clawdapus%0A',
+        '--json',
+      ]);
+      expect(integrationInstall.ok).toBe(true);
     } finally {
       fs.rmSync(workspacePath, { recursive: true, force: true });
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -722,6 +722,40 @@ const integrationCmd = program
 
 addWorkspaceOption(
   integrationCmd
+    .command('list')
+    .description('List supported optional integrations')
+    .option('--json', 'Emit structured JSON output')
+).action((opts) =>
+  runCommand(
+    opts,
+    () => ({
+      integrations: workgraph.integration.listIntegrations(),
+    }),
+    (result) => result.integrations.map((integration) =>
+      `${integration.id} (${integration.defaultTitle}) -> ${integration.defaultSourceUrl}`)
+  )
+);
+
+addWorkspaceOption(
+  integrationCmd
+    .command('install <integrationName>')
+    .description('Install an optional integration into this workspace')
+    .option('-a, --actor <name>', 'Agent name', DEFAULT_ACTOR)
+    .option('--owner <name>', 'Skill owner override')
+    .option('--title <title>', 'Skill title to store in workgraph')
+    .option('--source-url <url>', 'Source URL override for integration content')
+    .option('--force', 'Overwrite an existing imported integration skill')
+    .option('--json', 'Emit structured JSON output')
+).action((integrationName, opts) =>
+  runCommand(
+    opts,
+    () => installNamedIntegration(resolveWorkspacePath(opts), integrationName, opts),
+    renderInstalledIntegrationResult,
+  )
+);
+
+addWorkspaceOption(
+  integrationCmd
     .command('clawdapus')
     .description('Import Clawdapus SKILL.md into this workspace')
     .option('-a, --actor <name>', 'Agent name', DEFAULT_ACTOR)
@@ -737,21 +771,8 @@ addWorkspaceOption(
 ).action((opts) =>
   runCommand(
     opts,
-    async () => {
-      const workspacePath = resolveWorkspacePath(opts);
-      return workgraph.clawdapus.installClawdapusSkill(workspacePath, {
-        actor: opts.actor,
-        owner: opts.owner,
-        title: opts.title,
-        sourceUrl: opts.sourceUrl,
-        force: !!opts.force,
-      });
-    },
-    (result) => [
-      `${result.replacedExisting ? 'Updated' : 'Installed'} Clawdapus integration skill: ${result.skill.path}`,
-      `Source: ${result.sourceUrl}`,
-      `Status: ${String(result.skill.fields.status)}`,
-    ],
+    () => installNamedIntegration(resolveWorkspacePath(opts), 'clawdapus', opts),
+    renderInstalledIntegrationResult,
   )
 );
 
@@ -1740,6 +1761,36 @@ function parseSetPairs(pairs: string[]): Record<string, unknown> {
 function csv(value?: string): string[] | undefined {
   if (!value) return undefined;
   return String(value).split(',').map(s => s.trim()).filter(Boolean);
+}
+
+type IntegrationInstallCliOptions = JsonCapableOptions & {
+  actor: string;
+  owner?: string;
+  title?: string;
+  sourceUrl?: string;
+  force?: boolean;
+};
+
+function installNamedIntegration(
+  workspacePath: string,
+  integrationName: string,
+  opts: IntegrationInstallCliOptions,
+): Promise<workgraph.InstallSkillIntegrationResult> {
+  return workgraph.integration.installIntegration(workspacePath, integrationName, {
+    actor: opts.actor,
+    owner: opts.owner,
+    title: opts.title,
+    sourceUrl: opts.sourceUrl,
+    force: !!opts.force,
+  });
+}
+
+function renderInstalledIntegrationResult(result: workgraph.InstallSkillIntegrationResult): string[] {
+  return [
+    `${result.replacedExisting ? 'Updated' : 'Installed'} ${result.provider} integration skill: ${result.skill.path}`,
+    `Source: ${result.sourceUrl}`,
+    `Status: ${String(result.skill.fields.status)}`,
+  ];
 }
 
 function parseScalar(value: string): unknown {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,5 +22,7 @@ export * as searchQmdAdapter from './search-qmd-adapter.js';
 export * as trigger from './trigger.js';
 export * as mcpServer from './mcp-server.js';
 export * as clawdapus from './clawdapus.js';
+export * as integration from './integration.js';
+export * from './integration-core.js';
 export * from './runtime-adapter-contracts.js';
 export * from './adapter-cursor-cloud.js';

--- a/src/integration-core.ts
+++ b/src/integration-core.ts
@@ -1,0 +1,127 @@
+import { loadSkill, writeSkill, type WriteSkillOptions } from './skill.js';
+import type { PrimitiveInstance } from './types.js';
+
+export interface SkillIntegrationProvider {
+  id: string;
+  defaultTitle: string;
+  defaultSourceUrl: string;
+  distribution: string;
+  defaultTags: string[];
+  userAgent?: string;
+}
+
+export interface InstallSkillIntegrationOptions {
+  actor: string;
+  owner?: string;
+  title?: string;
+  sourceUrl?: string;
+  force?: boolean;
+  status?: WriteSkillOptions['status'];
+  tags?: string[];
+  fetchSkillMarkdown?: (sourceUrl: string) => Promise<string>;
+}
+
+export interface InstallSkillIntegrationResult {
+  provider: string;
+  skill: PrimitiveInstance;
+  sourceUrl: string;
+  importedAt: string;
+  replacedExisting: boolean;
+}
+
+export async function installSkillIntegration(
+  workspacePath: string,
+  provider: SkillIntegrationProvider,
+  options: InstallSkillIntegrationOptions,
+): Promise<InstallSkillIntegrationResult> {
+  const actor = options.actor.trim();
+  if (!actor) {
+    throw new Error(`${provider.id} integration requires a non-empty actor.`);
+  }
+
+  const title = options.title?.trim() || provider.defaultTitle;
+  const sourceUrl = options.sourceUrl?.trim() || provider.defaultSourceUrl;
+  const existing = loadSkillIfExists(workspacePath, title);
+  if (existing && !options.force) {
+    throw new Error(
+      `Skill "${title}" already exists at ${existing.path}. Use --force to refresh it from source.`,
+    );
+  }
+
+  const fetchSkillMarkdown =
+    options.fetchSkillMarkdown ??
+    ((url: string) => fetchSkillMarkdownFromUrl(url, provider.userAgent));
+  const markdown = await fetchSkillMarkdown(sourceUrl);
+  if (!markdown.trim()) {
+    throw new Error(`Downloaded ${provider.id} skill from ${sourceUrl} is empty.`);
+  }
+
+  const skill = writeSkill(workspacePath, title, markdown, actor, {
+    owner: options.owner ?? actor,
+    status: options.status,
+    distribution: provider.distribution,
+    tags: mergeTags(provider.defaultTags, options.tags),
+  });
+
+  return {
+    provider: provider.id,
+    skill,
+    sourceUrl,
+    importedAt: new Date().toISOString(),
+    replacedExisting: existing !== null,
+  };
+}
+
+export async function fetchSkillMarkdownFromUrl(
+  sourceUrl: string,
+  userAgent = '@versatly/workgraph optional-integration',
+): Promise<string> {
+  let response;
+  try {
+    response = await fetch(sourceUrl, {
+      headers: {
+        'user-agent': userAgent,
+      },
+    });
+  } catch (error) {
+    throw new Error(
+      `Failed to download skill from ${sourceUrl}: ${errorMessage(error)}`,
+    );
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download skill from ${sourceUrl}: HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+  return response.text();
+}
+
+function loadSkillIfExists(workspacePath: string, skillRef: string): PrimitiveInstance | null {
+  try {
+    return loadSkill(workspacePath, skillRef);
+  } catch (error) {
+    const message = errorMessage(error);
+    if (message.startsWith('Skill not found:')) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function mergeTags(defaultTags: string[], tags: string[] | undefined): string[] {
+  const merged = new Set<string>(['optional-integration']);
+  for (const tag of defaultTags) {
+    const normalized = tag.trim();
+    if (normalized) merged.add(normalized);
+  }
+  for (const tag of tags ?? []) {
+    const normalized = tag.trim();
+    if (normalized) merged.add(normalized);
+  }
+  return [...merged];
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { loadRegistry, saveRegistry } from './registry.js';
+import { installIntegration, listIntegrations } from './integration.js';
+import { loadSkill } from './skill.js';
+
+let workspacePath: string;
+
+beforeEach(() => {
+  workspacePath = fs.mkdtempSync(path.join(os.tmpdir(), 'wg-integration-'));
+  const registry = loadRegistry(workspacePath);
+  saveRegistry(workspacePath, registry);
+});
+
+afterEach(() => {
+  fs.rmSync(workspacePath, { recursive: true, force: true });
+});
+
+describe('integration registry', () => {
+  it('lists supported optional integrations', () => {
+    const integrations = listIntegrations();
+    expect(integrations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'clawdapus',
+          defaultTitle: 'clawdapus',
+        }),
+      ]),
+    );
+  });
+
+  it('installs clawdapus through generic integration dispatcher', async () => {
+    const result = await installIntegration(workspacePath, 'clawdapus', {
+      actor: 'agent-ops',
+      fetchSkillMarkdown: async () => '# Imported Through Registry',
+    });
+
+    expect(result.provider).toBe('clawdapus');
+    expect(result.skill.path).toBe('skills/clawdapus/SKILL.md');
+    expect(loadSkill(workspacePath, 'clawdapus').body).toContain('Imported Through Registry');
+  });
+
+  it('throws a clear error for unknown integrations', async () => {
+    await expect(
+      installIntegration(workspacePath, 'unknown-provider', {
+        actor: 'agent-ops',
+      }),
+    ).rejects.toThrow('Unknown integration "unknown-provider"');
+  });
+});

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -1,0 +1,60 @@
+import {
+  CLAWDAPUS_INTEGRATION_PROVIDER,
+  installClawdapusSkill,
+} from './clawdapus.js';
+import type {
+  InstallSkillIntegrationOptions,
+  InstallSkillIntegrationResult,
+  SkillIntegrationProvider,
+} from './integration-core.js';
+
+export interface IntegrationDescriptor {
+  id: string;
+  description: string;
+  defaultTitle: string;
+  defaultSourceUrl: string;
+}
+
+interface IntegrationRegistration {
+  provider: SkillIntegrationProvider;
+  description: string;
+  install: (
+    workspacePath: string,
+    options: InstallSkillIntegrationOptions,
+  ) => Promise<InstallSkillIntegrationResult>;
+}
+
+const INTEGRATIONS: Record<string, IntegrationRegistration> = {
+  clawdapus: {
+    provider: CLAWDAPUS_INTEGRATION_PROVIDER,
+    description: 'Infrastructure-layer governance skill import for AI agent containers.',
+    install: installClawdapusSkill,
+  },
+};
+
+export function listIntegrations(): IntegrationDescriptor[] {
+  return Object.values(INTEGRATIONS).map((integration) => ({
+    id: integration.provider.id,
+    description: integration.description,
+    defaultTitle: integration.provider.defaultTitle,
+    defaultSourceUrl: integration.provider.defaultSourceUrl,
+  }));
+}
+
+export async function installIntegration(
+  workspacePath: string,
+  integrationId: string,
+  options: InstallSkillIntegrationOptions,
+): Promise<InstallSkillIntegrationResult> {
+  const integration = INTEGRATIONS[integrationId.trim().toLowerCase()];
+  if (!integration) {
+    throw new Error(
+      `Unknown integration "${integrationId}". Supported integrations: ${supportedIntegrationList()}.`,
+    );
+  }
+  return integration.install(workspacePath, options);
+}
+
+function supportedIntegrationList(): string {
+  return Object.keys(INTEGRATIONS).sort().join(', ');
+}


### PR DESCRIPTION
Add an optional Clawdapus integration with a new CLI command to import its skill definition into a Workgraph workspace.

---
<p><a href="https://cursor.com/agents/bc-49a4dfda-3a76-4f9e-b781-1b83d6b9abae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49a4dfda-3a76-4f9e-b781-1b83d6b9abae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

