### PR TITLE
Server events and lenses

### DIFF
--- a/packages/control-api/src/server-events.ts
+++ b/packages/control-api/src/server-events.ts
@@ -1,0 +1,201 @@
+import { ledger as ledgerModule, type LedgerEntry, type LedgerOp } from '@versatly/workgraph-kernel';
+
+const ledger = ledgerModule;
+
+export type DashboardEventType =
+  | 'thread.created'
+  | 'thread.updated'
+  | 'thread.claimed'
+  | 'thread.done'
+  | 'thread.blocked'
+  | 'thread.released'
+  | 'ledger.appended'
+  | 'primitive.changed';
+
+export interface DashboardEvent {
+  id: string;
+  type: DashboardEventType;
+  path: string;
+  actor: string;
+  fields: Record<string, unknown>;
+  ts: string;
+}
+
+export function mapLedgerEntryToDashboardEvents(entry: LedgerEntry): DashboardEvent[] {
+  const id = readEventId(entry);
+  const base = {
+    id,
+    path: entry.target,
+    actor: entry.actor,
+    ts: entry.ts,
+  };
+
+  const events: DashboardEvent[] = [];
+  if (entry.type === 'thread') {
+    const threadEventType = toThreadEventType(entry.op);
+    if (threadEventType) {
+      events.push({
+        ...base,
+        type: threadEventType,
+        fields: deriveEventFields(entry),
+      });
+    }
+  }
+
+  if (shouldEmitPrimitiveChanged(entry)) {
+    events.push({
+      ...base,
+      type: 'primitive.changed',
+      fields: {
+        op: entry.op,
+        type: entry.type,
+        ...sanitizeData(entry.data),
+      },
+    });
+  }
+
+  events.push({
+    ...base,
+    type: 'ledger.appended',
+    fields: {
+      op: entry.op,
+      type: entry.type,
+      ...sanitizeData(entry.data),
+    },
+  });
+
+  return events;
+}
+
+export function listDashboardEventsSince(
+  workspacePath: string,
+  lastEventId: string | undefined,
+): DashboardEvent[] {
+  const entries = ledger.readAll(workspacePath);
+  const startIdx = resolveReplayStartIndex(entries, lastEventId);
+  return entries
+    .slice(startIdx)
+    .flatMap((entry) => mapLedgerEntryToDashboardEvents(entry));
+}
+
+export function subscribeToDashboardEvents(
+  workspacePath: string,
+  onEvent: (event: DashboardEvent) => void,
+): () => void {
+  return ledger.subscribe(workspacePath, (entry) => {
+    const events = mapLedgerEntryToDashboardEvents(entry);
+    for (const event of events) {
+      onEvent(event);
+    }
+  });
+}
+
+export function toSsePayload(event: DashboardEvent): string {
+  const body = JSON.stringify({
+    type: event.type,
+    path: event.path,
+    actor: event.actor,
+    fields: event.fields,
+    ts: event.ts,
+  });
+  return `id: ${event.id}\nevent: ${event.type}\ndata: ${body}\n\n`;
+}
+
+export function deriveEventFields(entry: LedgerEntry): Record<string, unknown> {
+  const fallback = sanitizeData(entry.data);
+  switch (entry.op) {
+    case 'claim':
+      return {
+        status: 'active',
+        owner: entry.actor,
+        ...fallback,
+      };
+    case 'release':
+    case 'reopen':
+      return {
+        status: 'open',
+        owner: null,
+        ...fallback,
+      };
+    case 'done':
+      return {
+        status: 'done',
+        ...fallback,
+      };
+    case 'block':
+      return {
+        status: 'blocked',
+        ...fallback,
+      };
+    case 'unblock':
+      return {
+        status: 'active',
+        ...fallback,
+      };
+    case 'cancel':
+      return {
+        status: 'cancelled',
+        owner: null,
+        ...fallback,
+      };
+    case 'delete':
+      return {
+        deleted: true,
+        ...fallback,
+      };
+    default:
+      return fallback;
+  }
+}
+
+function shouldEmitPrimitiveChanged(entry: LedgerEntry): boolean {
+  if (!entry.type) return false;
+  if (entry.target.startsWith('.workgraph/ledger')) return false;
+  return isPrimitiveMutationOp(entry.op);
+}
+
+function isPrimitiveMutationOp(op: LedgerOp): boolean {
+  return op === 'create' ||
+    op === 'update' ||
+    op === 'delete' ||
+    op === 'claim' ||
+    op === 'release' ||
+    op === 'done' ||
+    op === 'block' ||
+    op === 'unblock' ||
+    op === 'reopen' ||
+    op === 'cancel' ||
+    op === 'heartbeat' ||
+    op === 'handoff' ||
+    op === 'decompose';
+}
+
+function toThreadEventType(op: LedgerOp): DashboardEventType | undefined {
+  if (op === 'create') return 'thread.created';
+  if (op === 'update') return 'thread.updated';
+  if (op === 'claim') return 'thread.claimed';
+  if (op === 'done') return 'thread.done';
+  if (op === 'block') return 'thread.blocked';
+  if (op === 'release' || op === 'reopen') return 'thread.released';
+  if (op === 'unblock' || op === 'cancel' || op === 'heartbeat' || op === 'handoff' || op === 'decompose') {
+    return 'thread.updated';
+  }
+  return undefined;
+}
+
+function readEventId(entry: LedgerEntry): string {
+  if (entry.hash) return entry.hash;
+  return `${entry.ts}:${entry.actor}:${entry.op}:${entry.target}`;
+}
+
+function resolveReplayStartIndex(entries: LedgerEntry[], lastEventId: string | undefined): number {
+  if (!lastEventId) return 0;
+  const idx = entries.findIndex((entry) => entry.hash === lastEventId);
+  if (idx < 0) return 0;
+  return idx + 1;
+}
+
+function sanitizeData(data: Record<string, unknown> | undefined): Record<string, unknown> {
+  if (!data) return {};
+  return Object.fromEntries(Object.entries(data).filter(([, value]) => value !== undefined));
+}

--- a/packages/control-api/src/server-lenses.ts
+++ b/packages/control-api/src/server-lenses.ts
@@ -1,0 +1,421 @@
+import {
+  ledger as ledgerModule,
+  store as storeModule,
+  type LedgerEntry,
+  type PrimitiveInstance,
+} from '@versatly/workgraph-kernel';
+import { deriveEventFields } from './server-events.js';
+
+const ledger = ledgerModule;
+const store = storeModule;
+
+const STALE_THREAD_MS = 24 * 60 * 60 * 1_000;
+const AGENT_ONLINE_WINDOW_MS = 30 * 60 * 1_000;
+
+export interface LensOptions {
+  space?: string;
+}
+
+export interface AttentionLensResult {
+  threads: AttentionLensThread[];
+  summary: {
+    blocked: number;
+    stale: number;
+    urgent_unclaimed: number;
+  };
+}
+
+export interface AttentionLensThread {
+  path: string;
+  title: string;
+  status: string;
+  priority: string;
+  owner?: string;
+  space?: string;
+  updated?: string;
+  reason: 'blocked' | 'urgent_unclaimed' | 'stale' | 'unresolved_dependencies';
+  unresolvedDeps?: string[];
+}
+
+export interface AgentsLensResult {
+  agents: AgentLensSummary[];
+}
+
+export interface AgentLensSummary {
+  name: string;
+  lastSeen: string;
+  actionCount: number;
+  claimedThreads: string[];
+  online: boolean;
+}
+
+export interface SpacesLensResult {
+  spaces: SpaceLensSummary[];
+}
+
+export interface SpaceLensSummary {
+  name: string;
+  total: number;
+  open: number;
+  active: number;
+  blocked: number;
+  done: number;
+  progress: number;
+}
+
+export interface TimelineLensResult {
+  events: TimelineLensEvent[];
+}
+
+export interface TimelineLensEvent {
+  timestamp: string;
+  actor: string;
+  operation: string;
+  path: string;
+  threadTitle?: string;
+  changedFields: Record<string, unknown>;
+}
+
+export function buildAttentionLens(workspacePath: string, options: LensOptions = {}): AttentionLensResult {
+  const normalizedSpace = normalizeSpaceRef(options.space);
+  const nowMs = Date.now();
+  const claims = ledger.allClaims(workspacePath);
+  const allThreads = listThreads(workspacePath, normalizedSpace);
+  const threadByPath = new Map(allThreads.map((thread) => [thread.path, thread]));
+
+  const blocked = allThreads
+    .filter((thread) => threadStatus(thread) === 'blocked')
+    .sort(comparePriorityThenUpdatedAsc);
+  const urgentUnclaimed = allThreads
+    .filter((thread) =>
+      threadStatus(thread) === 'open' &&
+      normalizePriority(thread.fields.priority) === 'urgent' &&
+      !claims.has(thread.path))
+    .sort(comparePriorityThenUpdatedAsc);
+  const stale = allThreads
+    .filter((thread) =>
+      threadStatus(thread) === 'active' &&
+      isStaleThread(thread, nowMs))
+    .sort(comparePriorityThenUpdatedAsc);
+  const unresolvedDeps = allThreads
+    .map((thread) => ({ thread, unresolved: unresolvedDependencies(thread, threadByPath) }))
+    .filter((entry) =>
+      entry.unresolved.length > 0 &&
+      threadStatus(entry.thread) !== 'done' &&
+      threadStatus(entry.thread) !== 'cancelled')
+    .sort((a, b) => comparePriorityThenUpdatedAsc(a.thread, b.thread));
+
+  const prioritized = new Map<string, AttentionLensThread>();
+  for (const thread of blocked) {
+    prioritized.set(thread.path, toAttentionThread(thread, 'blocked'));
+  }
+  for (const thread of urgentUnclaimed) {
+    if (!prioritized.has(thread.path)) {
+      prioritized.set(thread.path, toAttentionThread(thread, 'urgent_unclaimed'));
+    }
+  }
+  for (const thread of stale) {
+    if (!prioritized.has(thread.path)) {
+      prioritized.set(thread.path, toAttentionThread(thread, 'stale'));
+    }
+  }
+  for (const entry of unresolvedDeps) {
+    if (!prioritized.has(entry.thread.path)) {
+      prioritized.set(
+        entry.thread.path,
+        toAttentionThread(entry.thread, 'unresolved_dependencies', entry.unresolved),
+      );
+    }
+  }
+
+  return {
+    threads: [...prioritized.values()],
+    summary: {
+      blocked: blocked.length,
+      stale: stale.length,
+      urgent_unclaimed: urgentUnclaimed.length,
+    },
+  };
+}
+
+export function buildAgentsLens(workspacePath: string, options: LensOptions = {}): AgentsLensResult {
+  const normalizedSpace = normalizeSpaceRef(options.space);
+  const threadByPath = buildThreadPathIndex(workspacePath);
+  const allEntries = ledger.readAll(workspacePath);
+  const entries = filterLedgerBySpace(allEntries, normalizedSpace, threadByPath);
+  const claims = [...ledger.allClaims(workspacePath).entries()]
+    .filter(([threadPath]) => threadInSpace(threadByPath.get(threadPath), normalizedSpace));
+
+  const byAgent = new Map<string, AgentLensSummary>();
+  for (const entry of entries) {
+    const current = byAgent.get(entry.actor) ?? {
+      name: entry.actor,
+      lastSeen: entry.ts,
+      actionCount: 0,
+      claimedThreads: [],
+      online: false,
+    };
+    current.actionCount += 1;
+    if (entry.ts > current.lastSeen) current.lastSeen = entry.ts;
+    byAgent.set(entry.actor, current);
+  }
+
+  for (const [threadPath, owner] of claims) {
+    const current = byAgent.get(owner) ?? {
+      name: owner,
+      lastSeen: '',
+      actionCount: 0,
+      claimedThreads: [],
+      online: false,
+    };
+    if (!current.claimedThreads.includes(threadPath)) {
+      current.claimedThreads.push(threadPath);
+    }
+    byAgent.set(owner, current);
+  }
+
+  const nowMs = Date.now();
+  const agents = [...byAgent.values()]
+    .map((agent) => ({
+      ...agent,
+      claimedThreads: [...agent.claimedThreads].sort((a, b) => a.localeCompare(b)),
+      online: isOnline(agent.lastSeen, nowMs),
+    }))
+    .sort((a, b) => {
+      if (a.online !== b.online) return a.online ? -1 : 1;
+      return b.lastSeen.localeCompare(a.lastSeen) || b.actionCount - a.actionCount || a.name.localeCompare(b.name);
+    });
+
+  return { agents };
+}
+
+export function buildSpacesLens(workspacePath: string, options: LensOptions = {}): SpacesLensResult {
+  const normalizedSpace = normalizeSpaceRef(options.space);
+  const allThreads = listThreads(workspacePath, normalizedSpace);
+  const bySpace = new Map<string, SpaceLensSummary>();
+
+  for (const thread of allThreads) {
+    const spaceName = normalizeSpaceRef(thread.fields.space) ?? 'unassigned';
+    const current = bySpace.get(spaceName) ?? {
+      name: spaceName,
+      total: 0,
+      open: 0,
+      active: 0,
+      blocked: 0,
+      done: 0,
+      progress: 0,
+    };
+    current.total += 1;
+    const status = threadStatus(thread);
+    if (status === 'open') current.open += 1;
+    if (status === 'active') current.active += 1;
+    if (status === 'blocked') current.blocked += 1;
+    if (status === 'done') current.done += 1;
+    bySpace.set(spaceName, current);
+  }
+
+  const spaces = [...bySpace.values()]
+    .map((space) => ({
+      ...space,
+      progress: space.total === 0 ? 0 : roundToTwo((space.done / space.total) * 100),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return { spaces };
+}
+
+export function buildTimelineLens(workspacePath: string, options: LensOptions = {}): TimelineLensResult {
+  const normalizedSpace = normalizeSpaceRef(options.space);
+  const threadByPath = buildThreadPathIndex(workspacePath);
+  const allEntries = ledger.readAll(workspacePath);
+  const entries = filterLedgerBySpace(allEntries, normalizedSpace, threadByPath)
+    .slice(-50)
+    .reverse();
+
+  return {
+    events: entries.map((entry) => {
+      const threadTitle = resolveThreadTitle(entry, threadByPath);
+      return {
+        timestamp: entry.ts,
+        actor: entry.actor,
+        operation: entry.op,
+        path: entry.target,
+        ...(threadTitle ? { threadTitle } : {}),
+        changedFields: deriveEventFields(entry),
+      };
+    }),
+  };
+}
+
+function listThreads(workspacePath: string, space: string | undefined): PrimitiveInstance[] {
+  const allThreads = store.list(workspacePath, 'thread');
+  return allThreads.filter((thread) => threadInSpace(thread, space));
+}
+
+function buildThreadPathIndex(workspacePath: string): Map<string, PrimitiveInstance> {
+  const threads = store.list(workspacePath, 'thread');
+  return new Map(threads.map((thread) => [thread.path, thread]));
+}
+
+function filterLedgerBySpace(
+  entries: LedgerEntry[],
+  space: string | undefined,
+  threadByPath: Map<string, PrimitiveInstance>,
+): LedgerEntry[] {
+  if (!space) return entries;
+  return entries.filter((entry) => {
+    const targetThread = resolveThreadForLedgerEntry(entry, threadByPath);
+    return threadInSpace(targetThread, space);
+  });
+}
+
+function resolveThreadForLedgerEntry(
+  entry: LedgerEntry,
+  threadByPath: Map<string, PrimitiveInstance>,
+): PrimitiveInstance | undefined {
+  if (entry.type === 'thread' || looksLikeThreadPath(entry.target)) {
+    return threadByPath.get(normalizeThreadPath(entry.target));
+  }
+  return undefined;
+}
+
+function resolveThreadTitle(
+  entry: LedgerEntry,
+  threadByPath: Map<string, PrimitiveInstance>,
+): string | undefined {
+  const thread = resolveThreadForLedgerEntry(entry, threadByPath);
+  if (!thread) return undefined;
+  const title = String(thread.fields.title ?? '').trim();
+  return title || thread.path;
+}
+
+function unresolvedDependencies(
+  thread: PrimitiveInstance,
+  threadByPath: Map<string, PrimitiveInstance>,
+): string[] {
+  const deps = Array.isArray(thread.fields.deps) ? thread.fields.deps : [];
+  const unresolved: string[] = [];
+  for (const dep of deps) {
+    const normalized = normalizeThreadPath(dep);
+    if (!normalized) continue;
+    if (normalized.startsWith('external/')) {
+      unresolved.push(normalized);
+      continue;
+    }
+    const dependencyThread = threadByPath.get(normalized);
+    if (!dependencyThread || threadStatus(dependencyThread) !== 'done') {
+      unresolved.push(normalized);
+    }
+  }
+  return unresolved;
+}
+
+function toAttentionThread(
+  thread: PrimitiveInstance,
+  reason: AttentionLensThread['reason'],
+  unresolved: string[] = [],
+): AttentionLensThread {
+  const owner = readOptionalString(thread.fields.owner);
+  const space = normalizeSpaceRef(thread.fields.space);
+  const updated = readOptionalString(thread.fields.updated);
+  return {
+    path: thread.path,
+    title: String(thread.fields.title ?? thread.path),
+    status: threadStatus(thread),
+    priority: normalizePriority(thread.fields.priority),
+    ...(owner ? { owner } : {}),
+    ...(space ? { space } : {}),
+    ...(updated ? { updated } : {}),
+    reason,
+    ...(unresolved.length > 0 ? { unresolvedDeps: unresolved } : {}),
+  };
+}
+
+function isStaleThread(thread: PrimitiveInstance, nowMs: number): boolean {
+  const updatedTs = parseTimestampMs(thread.fields.updated ?? thread.fields.created);
+  if (!Number.isFinite(updatedTs)) return false;
+  return nowMs - updatedTs > STALE_THREAD_MS;
+}
+
+function isOnline(lastSeen: string, nowMs: number): boolean {
+  const ts = parseTimestampMs(lastSeen);
+  if (!Number.isFinite(ts)) return false;
+  return nowMs - ts <= AGENT_ONLINE_WINDOW_MS;
+}
+
+function comparePriorityThenUpdatedAsc(a: PrimitiveInstance, b: PrimitiveInstance): number {
+  const priorityDelta = priorityRank(a.fields.priority) - priorityRank(b.fields.priority);
+  if (priorityDelta !== 0) return priorityDelta;
+  const updatedA = parseTimestampMs(a.fields.updated ?? a.fields.created);
+  const updatedB = parseTimestampMs(b.fields.updated ?? b.fields.created);
+  const safeA = Number.isFinite(updatedA) ? updatedA : Number.MAX_SAFE_INTEGER;
+  const safeB = Number.isFinite(updatedB) ? updatedB : Number.MAX_SAFE_INTEGER;
+  return safeA - safeB;
+}
+
+function priorityRank(value: unknown): number {
+  const normalized = normalizePriority(value);
+  if (normalized === 'urgent') return 0;
+  if (normalized === 'high') return 1;
+  if (normalized === 'medium') return 2;
+  if (normalized === 'low') return 3;
+  return 4;
+}
+
+function threadStatus(thread: PrimitiveInstance): string {
+  return String(thread.fields.status ?? '');
+}
+
+function normalizePriority(value: unknown): string {
+  return String(value ?? 'medium').trim().toLowerCase();
+}
+
+function normalizeSpaceRef(value: unknown): string | undefined {
+  const raw = readOptionalString(value);
+  if (!raw) return undefined;
+  const unwrapped = raw.startsWith('[[') && raw.endsWith(']]')
+    ? raw.slice(2, -2)
+    : raw;
+  return unwrapped.endsWith('.md') ? unwrapped : `${unwrapped}.md`;
+}
+
+function threadInSpace(thread: PrimitiveInstance | undefined, space: string | undefined): boolean {
+  if (!space) return true;
+  if (!thread) return false;
+  return normalizeSpaceRef(thread.fields.space) === space;
+}
+
+function looksLikeThreadPath(value: string): boolean {
+  return value.replace(/\\/g, '/').startsWith('threads/');
+}
+
+function normalizeThreadPath(value: unknown): string {
+  const raw = String(value ?? '').trim();
+  if (!raw) return '';
+  const unwrapped = raw.startsWith('[[') && raw.endsWith(']]')
+    ? raw.slice(2, -2)
+    : raw;
+  const primary = unwrapped.split('|')[0].trim().split('#')[0].trim();
+  if (!primary) return '';
+  if (primary.startsWith('external/')) return primary;
+  const withPathPrefix = primary.startsWith('threads/')
+    ? primary
+    : `threads/${primary}`;
+  return withPathPrefix.endsWith('.md') ? withPathPrefix : `${withPathPrefix}.md`;
+}
+
+function parseTimestampMs(value: unknown): number {
+  const parsed = Date.parse(String(value ?? ''));
+  if (!Number.isFinite(parsed)) return Number.NaN;
+  return parsed;
+}
+
+function roundToTwo(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}

--- a/packages/control-api/src/server-webhooks.ts
+++ b/packages/control-api/src/server-webhooks.ts
@@ -1,0 +1,235 @@
+import crypto, { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { DashboardEvent } from './server-events.js';
+
+const WEBHOOKS_PATH = '.workgraph/webhooks.json';
+const WEBHOOKS_VERSION = 1;
+
+interface WebhookStoreFile {
+  version: number;
+  webhooks: StoredWebhook[];
+}
+
+interface StoredWebhook {
+  id: string;
+  url: string;
+  events: string[];
+  secret?: string;
+  createdAt: string;
+}
+
+export interface WebhookView {
+  id: string;
+  url: string;
+  events: string[];
+  createdAt: string;
+  hasSecret: boolean;
+}
+
+export interface RegisterWebhookInput {
+  url: string;
+  events: string[];
+  secret?: string;
+}
+
+export function listWebhooks(workspacePath: string): WebhookView[] {
+  const store = readWebhookStore(workspacePath);
+  return store.webhooks.map(toWebhookView);
+}
+
+export function registerWebhook(workspacePath: string, input: RegisterWebhookInput): WebhookView {
+  const url = normalizeWebhookUrl(input.url);
+  const events = normalizeEventPatterns(input.events);
+  const secret = readOptionalString(input.secret);
+
+  const store = readWebhookStore(workspacePath);
+  const record: StoredWebhook = {
+    id: randomUUID(),
+    url,
+    events,
+    createdAt: new Date().toISOString(),
+    ...(secret ? { secret } : {}),
+  };
+  store.webhooks.push(record);
+  writeWebhookStore(workspacePath, store);
+  return toWebhookView(record);
+}
+
+export function deleteWebhook(workspacePath: string, id: string): boolean {
+  const normalizedId = String(id ?? '').trim();
+  if (!normalizedId) return false;
+  const store = readWebhookStore(workspacePath);
+  const before = store.webhooks.length;
+  store.webhooks = store.webhooks.filter((item) => item.id !== normalizedId);
+  if (store.webhooks.length === before) return false;
+  writeWebhookStore(workspacePath, store);
+  return true;
+}
+
+export async function dispatchWebhookEvent(workspacePath: string, event: DashboardEvent): Promise<void> {
+  const store = readWebhookStore(workspacePath);
+  const matching = store.webhooks.filter((webhook) =>
+    webhook.events.some((pattern) => eventPatternMatches(pattern, event.type))
+  );
+  if (matching.length === 0) return;
+
+  const payload = JSON.stringify({
+    id: event.id,
+    type: event.type,
+    path: event.path,
+    actor: event.actor,
+    fields: event.fields,
+    ts: event.ts,
+  });
+  await Promise.allSettled(
+    matching.map(async (webhook) => {
+      const headers: Record<string, string> = {
+        'content-type': 'application/json',
+      };
+      if (webhook.secret) {
+        headers['X-WorkGraph-Signature'] = signPayload(payload, webhook.secret);
+      }
+      const response = await fetch(webhook.url, {
+        method: 'POST',
+        headers,
+        body: payload,
+      });
+      if (!response.ok) {
+        throw new Error(`Webhook ${webhook.id} responded with status ${response.status}.`);
+      }
+    }),
+  );
+}
+
+function readWebhookStore(workspacePath: string): WebhookStoreFile {
+  const filePath = webhookFilePath(workspacePath);
+  if (!fs.existsSync(filePath)) {
+    return {
+      version: WEBHOOKS_VERSION,
+      webhooks: [],
+    };
+  }
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as WebhookStoreFile;
+    if (!Array.isArray(parsed.webhooks)) {
+      throw new Error('Invalid webhook store shape.');
+    }
+    return {
+      version: WEBHOOKS_VERSION,
+      webhooks: parsed.webhooks
+        .map((webhook) => sanitizeStoredWebhook(webhook))
+        .filter((entry): entry is StoredWebhook => entry !== null),
+    };
+  } catch {
+    return {
+      version: WEBHOOKS_VERSION,
+      webhooks: [],
+    };
+  }
+}
+
+function writeWebhookStore(workspacePath: string, store: WebhookStoreFile): void {
+  const filePath = webhookFilePath(workspacePath);
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  const serialized: WebhookStoreFile = {
+    version: WEBHOOKS_VERSION,
+    webhooks: store.webhooks.map((webhook) => ({
+      id: webhook.id,
+      url: webhook.url,
+      events: webhook.events,
+      ...(webhook.secret ? { secret: webhook.secret } : {}),
+      createdAt: webhook.createdAt,
+    })),
+  };
+  fs.writeFileSync(filePath, JSON.stringify(serialized, null, 2) + '\n', 'utf-8');
+}
+
+function webhookFilePath(workspacePath: string): string {
+  return path.join(workspacePath, WEBHOOKS_PATH);
+}
+
+function normalizeWebhookUrl(value: string): string {
+  const raw = String(value ?? '').trim();
+  if (!raw) {
+    throw new Error('Missing webhook url.');
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error(`Invalid webhook url "${raw}".`);
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`Invalid webhook url "${raw}". Expected http(s).`);
+  }
+  return parsed.toString();
+}
+
+function normalizeEventPatterns(value: string[]): string[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error('Missing webhook events. Provide at least one event pattern.');
+  }
+  const normalized = value
+    .map((item) => String(item).trim())
+    .filter(Boolean);
+  if (normalized.length === 0) {
+    throw new Error('Missing webhook events. Provide at least one event pattern.');
+  }
+  return [...new Set(normalized)];
+}
+
+function signPayload(payload: string, secret: string): string {
+  const digest = crypto.createHmac('sha256', secret).update(payload).digest('hex');
+  return `sha256=${digest}`;
+}
+
+function eventPatternMatches(pattern: string, eventType: string): boolean {
+  if (pattern === '*') return true;
+  if (pattern.endsWith('*')) {
+    return eventType.startsWith(pattern.slice(0, -1));
+  }
+  return pattern === eventType;
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function sanitizeStoredWebhook(raw: unknown): StoredWebhook | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const candidate = raw as Partial<StoredWebhook>;
+  const id = readOptionalString(candidate.id);
+  const url = readOptionalString(candidate.url);
+  const createdAt = readOptionalString(candidate.createdAt) ?? new Date(0).toISOString();
+  if (!id || !url) return null;
+  const events = normalizeStoredEvents(candidate.events);
+  if (events.length === 0) return null;
+  return {
+    id,
+    url,
+    events,
+    createdAt,
+    ...(readOptionalString(candidate.secret) ? { secret: readOptionalString(candidate.secret)! } : {}),
+  };
+}
+
+function normalizeStoredEvents(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => String(item).trim())
+    .filter(Boolean);
+}
+
+function toWebhookView(webhook: StoredWebhook): WebhookView {
+  return {
+    id: webhook.id,
+    url: webhook.url,
+    events: [...webhook.events],
+    createdAt: webhook.createdAt,
+    hasSecret: typeof webhook.secret === 'string' && webhook.secret.length > 0,
+  };
+}

--- a/packages/control-api/src/server.ts
+++ b/packages/control-api/src/server.ts
@@ -7,7 +7,27 @@ import {
   thread as threadModule,
   workspace as workspaceModule,
 } from '@versatly/workgraph-kernel';
-import { startWorkgraphMcpHttpServer } from '@versatly/workgraph-mcp-server';
+import {
+  startWorkgraphMcpHttpServer,
+  type WorkgraphMcpHttpServerHandle,
+} from '@versatly/workgraph-mcp-server';
+import {
+  buildAgentsLens,
+  buildAttentionLens,
+  buildSpacesLens,
+  buildTimelineLens,
+} from './server-lenses.js';
+import {
+  listDashboardEventsSince,
+  subscribeToDashboardEvents,
+  toSsePayload,
+} from './server-events.js';
+import {
+  deleteWebhook,
+  dispatchWebhookEvent,
+  listWebhooks,
+  registerWebhook,
+} from './server-webhooks.js';
 
 const ledger = ledgerModule;
 const orientation = orientationModule;
@@ -23,6 +43,7 @@ const DEFAULT_LEDGER_LIMIT = 20;
 const DEFAULT_THREADS_LIMIT = 100;
 const MAX_LEDGER_LIMIT = 500;
 const MAX_THREADS_LIMIT = 1_000;
+const SSE_KEEPALIVE_MS = 15_000;
 
 type LogLevel = 'info' | 'warn' | 'error';
 
@@ -77,6 +98,12 @@ interface ThreadCreateRequestBody {
   tags?: unknown;
 }
 
+interface WebhookCreateRequestBody {
+  url?: unknown;
+  events?: unknown;
+  secret?: unknown;
+}
+
 export async function startWorkgraphServer(options: WorkgraphServerOptions): Promise<WorkgraphServerHandle> {
   const workspacePath = path.resolve(options.workspacePath);
   const host = readNonEmptyString(options.host) ?? DEFAULT_HOST;
@@ -85,22 +112,35 @@ export async function startWorkgraphServer(options: WorkgraphServerOptions): Pro
   const defaultActor = readNonEmptyString(options.defaultActor) ?? 'anonymous';
 
   const workspaceInitialized = ensureWorkspaceInitialized(workspacePath);
-
-  const handle = await startWorkgraphMcpHttpServer({
-    workspacePath,
-    defaultActor,
-    host,
-    port,
-    endpointPath,
-    bearerToken: options.bearerToken,
-    onApp: ({ app, bearerAuthMiddleware }) => {
-      app.use('/api', bearerAuthMiddleware);
-      registerRestRoutes(app, workspacePath, defaultActor);
-    },
+  const unsubscribeWebhookDispatch = subscribeToDashboardEvents(workspacePath, (event) => {
+    void dispatchWebhookEvent(workspacePath, event);
   });
+
+  let handle: WorkgraphMcpHttpServerHandle;
+  try {
+    handle = await startWorkgraphMcpHttpServer({
+      workspacePath,
+      defaultActor,
+      host,
+      port,
+      endpointPath,
+      bearerToken: options.bearerToken,
+      onApp: ({ app, bearerAuthMiddleware }) => {
+        app.use('/api', bearerAuthMiddleware);
+        registerRestRoutes(app, workspacePath, defaultActor);
+      },
+    });
+  } catch (error) {
+    unsubscribeWebhookDispatch();
+    throw error;
+  }
 
   return {
     ...handle,
+    close: async () => {
+      unsubscribeWebhookDispatch();
+      await handle.close();
+    },
     workspacePath,
     workspaceInitialized,
   };
@@ -185,6 +225,53 @@ export function loadServerOptionsFromEnv(env: NodeJS.ProcessEnv): WorkgraphServe
 }
 
 function registerRestRoutes(app: any, workspacePath: string, defaultActor: string): void {
+  app.get('/api/events', (req: any, res: any) => {
+    try {
+      const lastEventId = readNonEmptyString(req.headers?.['last-event-id']);
+      res.setHeader('Content-Type', 'text/event-stream; charset=utf-8');
+      res.setHeader('Cache-Control', 'no-cache, no-transform');
+      res.setHeader('Connection', 'keep-alive');
+      res.setHeader('X-Accel-Buffering', 'no');
+      if (typeof res.flushHeaders === 'function') {
+        res.flushHeaders();
+      }
+      if (!safeStreamWrite(res, ':connected\n\n')) return;
+
+      const replay = listDashboardEventsSince(workspacePath, lastEventId);
+      for (const event of replay) {
+        if (!safeStreamWrite(res, toSsePayload(event))) {
+          return;
+        }
+      }
+
+      const unsubscribe = subscribeToDashboardEvents(workspacePath, (event) => {
+        safeStreamWrite(res, toSsePayload(event));
+      });
+      const keepAlive = setInterval(() => {
+        safeStreamWrite(res, ':keepalive\n\n');
+      }, SSE_KEEPALIVE_MS);
+      if (typeof keepAlive.unref === 'function') {
+        keepAlive.unref();
+      }
+
+      let cleaned = false;
+      const cleanup = () => {
+        if (cleaned) return;
+        cleaned = true;
+        clearInterval(keepAlive);
+        unsubscribe();
+      };
+      req.on('close', cleanup);
+      req.on('aborted', cleanup);
+      res.on('close', cleanup);
+      res.on('error', cleanup);
+    } catch (error) {
+      if (!res.headersSent) {
+        writeRouteError(res, error);
+      }
+    }
+  });
+
   app.get('/api/status', (_req: any, res: any) => {
     try {
       const snapshot = orientation.statusSnapshot(workspacePath);
@@ -293,6 +380,121 @@ function registerRestRoutes(app: any, workspacePath: string, defaultActor: strin
         ok: true,
         count: entries.length,
         entries,
+      });
+    } catch (error) {
+      writeRouteError(res, error);
+    }
+  });
+
+  app.get('/api/lens/:name', (req: any, res: any) => {
+    try {
+      const lensName = readNonEmptyString(req.params?.name)?.toLowerCase();
+      const space = readNonEmptyString(req.query?.space);
+      if (!lensName) {
+        res.status(400).json({
+          ok: false,
+          error: 'Lens name is required.',
+        });
+        return;
+      }
+
+      if (lensName === 'attention') {
+        res.json({
+          ok: true,
+          ...buildAttentionLens(workspacePath, { space }),
+        });
+        return;
+      }
+      if (lensName === 'agents') {
+        res.json({
+          ok: true,
+          ...buildAgentsLens(workspacePath, { space }),
+        });
+        return;
+      }
+      if (lensName === 'spaces') {
+        res.json({
+          ok: true,
+          ...buildSpacesLens(workspacePath, { space }),
+        });
+        return;
+      }
+      if (lensName === 'timeline') {
+        res.json({
+          ok: true,
+          ...buildTimelineLens(workspacePath, { space }),
+        });
+        return;
+      }
+
+      res.status(404).json({
+        ok: false,
+        error: `Unknown lens "${lensName}".`,
+      });
+    } catch (error) {
+      writeRouteError(res, error);
+    }
+  });
+
+  app.get('/api/webhooks', (_req: any, res: any) => {
+    try {
+      const webhooks = listWebhooks(workspacePath);
+      res.json({
+        ok: true,
+        count: webhooks.length,
+        webhooks,
+      });
+    } catch (error) {
+      writeRouteError(res, error);
+    }
+  });
+
+  app.post('/api/webhooks', (req: any, res: any) => {
+    try {
+      const payload = toRecord(req.body) as WebhookCreateRequestBody;
+      const url = readNonEmptyString(payload.url);
+      if (!url) {
+        throw new Error('Missing required field "url".');
+      }
+      const events = parseStringList(payload.events);
+      if (!events || events.length === 0) {
+        throw new Error('Missing required field "events".');
+      }
+      const webhook = registerWebhook(workspacePath, {
+        url,
+        events,
+        secret: readNonEmptyString(payload.secret),
+      });
+      res.status(201).json({
+        ok: true,
+        webhook,
+      });
+    } catch (error) {
+      writeRouteError(res, error);
+    }
+  });
+
+  app.delete('/api/webhooks/:id', (req: any, res: any) => {
+    try {
+      const webhookId = readNonEmptyString(req.params?.id);
+      if (!webhookId) {
+        res.status(400).json({
+          ok: false,
+          error: 'Webhook id is required.',
+        });
+        return;
+      }
+      const deleted = deleteWebhook(workspacePath, webhookId);
+      if (!deleted) {
+        res.status(404).json({
+          ok: false,
+          error: `Webhook not found: ${webhookId}`,
+        });
+        return;
+      }
+      res.json({
+        ok: true,
+        id: webhookId,
       });
     } catch (error) {
       writeRouteError(res, error);
@@ -548,6 +750,16 @@ function safeDecodeURIComponent(value: string): string {
     return decodeURIComponent(value);
   } catch {
     return value;
+  }
+}
+
+function safeStreamWrite(res: any, chunk: string): boolean {
+  if (res.writableEnded || res.destroyed) return false;
+  try {
+    res.write(chunk);
+    return true;
+  } catch {
+    return false;
   }
 }
 

--- a/packages/kernel/src/ledger.ts
+++ b/packages/kernel/src/ledger.ts
@@ -20,6 +20,9 @@ const LEDGER_CHAIN_FILE = '.workgraph/ledger-chain.json';
 const LEDGER_INDEX_VERSION = 1;
 const LEDGER_CHAIN_VERSION = 1;
 const LEDGER_GENESIS_HASH = 'GENESIS';
+const LEDGER_APPEND_SUBSCRIBERS = new Map<string, Set<LedgerAppendSubscriber>>();
+
+export type LedgerAppendSubscriber = (entry: LedgerEntry) => void;
 
 // ---------------------------------------------------------------------------
 // Core operations
@@ -66,7 +69,27 @@ export function append(
   fs.appendFileSync(lPath, JSON.stringify(entry) + '\n', 'utf-8');
   updateIndexWithEntry(workspacePath, entry);
   updateChainStateWithEntry(workspacePath, entry);
+  notifyAppendSubscribers(workspacePath, entry);
   return entry;
+}
+
+export function subscribe(
+  workspacePath: string,
+  subscriber: LedgerAppendSubscriber,
+): () => void {
+  const key = normalizeWorkspaceKey(workspacePath);
+  const listeners = LEDGER_APPEND_SUBSCRIBERS.get(key) ?? new Set<LedgerAppendSubscriber>();
+  listeners.add(subscriber);
+  LEDGER_APPEND_SUBSCRIBERS.set(key, listeners);
+
+  return () => {
+    const existing = LEDGER_APPEND_SUBSCRIBERS.get(key);
+    if (!existing) return;
+    existing.delete(subscriber);
+    if (existing.size === 0) {
+      LEDGER_APPEND_SUBSCRIBERS.delete(key);
+    }
+  };
 }
 
 export function readAll(workspacePath: string): LedgerEntry[] {
@@ -417,4 +440,20 @@ function stableStringify(value: unknown): string {
   const obj = value as Record<string, unknown>;
   const keys = Object.keys(obj).sort();
   return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringify(obj[key])}`).join(',')}}`;
+}
+
+function notifyAppendSubscribers(workspacePath: string, entry: LedgerEntry): void {
+  const listeners = LEDGER_APPEND_SUBSCRIBERS.get(normalizeWorkspaceKey(workspacePath));
+  if (!listeners || listeners.size === 0) return;
+  for (const listener of listeners) {
+    try {
+      listener(entry);
+    } catch {
+      // Subscriber failures should never break ledger append semantics.
+    }
+  }
+}
+
+function normalizeWorkspaceKey(workspacePath: string): string {
+  return path.resolve(workspacePath);
 }

--- a/src/server-events-and-lenses.test.ts
+++ b/src/server-events-and-lenses.test.ts
@@ -1,0 +1,318 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import matter from 'gray-matter';
+import * as ledger from './ledger.js';
+import * as thread from './thread.js';
+import { startWorkgraphServer } from './server.js';
+
+let workspacePath: string;
+
+beforeEach(() => {
+  workspacePath = fs.mkdtempSync(path.join(os.tmpdir(), 'wg-server-events-'));
+});
+
+afterEach(() => {
+  fs.rmSync(workspacePath, { recursive: true, force: true });
+});
+
+describe('workgraph server reactive dashboard endpoints', () => {
+  it('streams SSE events with Last-Event-ID replay semantics', async () => {
+    const handle = await startWorkgraphServer({
+      workspacePath,
+      host: '127.0.0.1',
+      port: 0,
+      bearerToken: 'secret',
+    });
+
+    try {
+      const first = thread.createThread(workspacePath, 'Replay first', 'Goal', 'agent-a');
+      const second = thread.createThread(workspacePath, 'Replay second', 'Goal', 'agent-a');
+      const recentEntries = ledger.recent(workspacePath, 2);
+      const firstHash = recentEntries[0]?.hash;
+      expect(firstHash).toBeTruthy();
+
+      const client = await connectSse(`${handle.baseUrl}/api/events`, {
+        authorization: 'Bearer secret',
+        'last-event-id': firstHash!,
+      });
+      try {
+        await waitFor(() =>
+          client.text().includes(`"path":"${second.path}"`) &&
+          !client.text().includes(`"path":"${first.path}"`),
+        );
+
+        thread.claim(workspacePath, second.path, 'agent-live');
+        await waitFor(() =>
+          client.text().includes('event: thread.claimed') &&
+          client.text().includes(`"path":"${second.path}"`) &&
+          client.text().includes('"status":"active"'),
+        );
+      } finally {
+        client.close();
+      }
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('returns smart lens aggregations with optional space filter', async () => {
+    const handle = await startWorkgraphServer({
+      workspacePath,
+      host: '127.0.0.1',
+      port: 0,
+    });
+    try {
+      const blocked = thread.createThread(workspacePath, 'Infra blocked', 'Blocked goal', 'seed', {
+        space: 'spaces/infrastructure',
+        priority: 'high',
+      });
+      thread.claim(workspacePath, blocked.path, 'agent-blocked');
+      thread.block(workspacePath, blocked.path, 'agent-blocked', 'external/vendor-api', 'Waiting on vendor');
+
+      thread.createThread(workspacePath, 'Infra urgent open', 'Urgent unclaimed', 'seed', {
+        space: 'spaces/infrastructure',
+        priority: 'urgent',
+      });
+
+      const stale = thread.createThread(workspacePath, 'Infra stale active', 'Stale active', 'seed', {
+        space: 'spaces/infrastructure',
+      });
+      thread.claim(workspacePath, stale.path, 'agent-stale');
+      setThreadUpdatedTimestamp(workspacePath, stale.path, new Date(Date.now() - (48 * 60 * 60 * 1_000)).toISOString());
+
+      thread.createThread(workspacePath, 'Dependency source', 'Still open dependency', 'seed', {
+        space: 'spaces/infrastructure',
+      });
+      thread.createThread(workspacePath, 'Needs dependency', 'Blocked by [[threads/dependency-source.md]]', 'seed', {
+        space: 'spaces/infrastructure',
+      });
+
+      const frontendDone = thread.createThread(workspacePath, 'Frontend done', 'Frontend goal', 'seed', {
+        space: 'spaces/frontend',
+      });
+      thread.claim(workspacePath, frontendDone.path, 'agent-frontend');
+      thread.done(workspacePath, frontendDone.path, 'agent-frontend', 'Done from test https://github.com/Versatly/workgraph/pull/9');
+
+      const attentionResponse = await fetch(`${handle.baseUrl}/api/lens/attention?space=spaces/infrastructure.md`);
+      const attentionBody = await attentionResponse.json() as {
+        ok: boolean;
+        threads: Array<{ path: string; reason: string }>;
+        summary: { blocked: number; stale: number; urgent_unclaimed: number };
+      };
+      expect(attentionResponse.status).toBe(200);
+      expect(attentionBody.ok).toBe(true);
+      expect(attentionBody.summary).toEqual({
+        blocked: 1,
+        stale: 1,
+        urgent_unclaimed: 1,
+      });
+      expect(attentionBody.threads[0]).toMatchObject({
+        path: blocked.path,
+        reason: 'blocked',
+      });
+      expect(attentionBody.threads.some((item) => item.reason === 'unresolved_dependencies')).toBe(true);
+
+      const agentsResponse = await fetch(`${handle.baseUrl}/api/lens/agents?space=spaces/infrastructure.md`);
+      const agentsBody = await agentsResponse.json() as {
+        ok: boolean;
+        agents: Array<{ name: string; actionCount: number; claimedThreads: string[]; online: boolean }>;
+      };
+      expect(agentsResponse.status).toBe(200);
+      expect(agentsBody.ok).toBe(true);
+      const blockedAgent = agentsBody.agents.find((agent) => agent.name === 'agent-blocked');
+      expect(blockedAgent).toBeTruthy();
+      expect(blockedAgent!.actionCount).toBeGreaterThan(0);
+      expect(blockedAgent!.claimedThreads).toContain(blocked.path);
+      expect(typeof blockedAgent!.online).toBe('boolean');
+
+      const spacesResponse = await fetch(`${handle.baseUrl}/api/lens/spaces`);
+      const spacesBody = await spacesResponse.json() as {
+        ok: boolean;
+        spaces: Array<{ name: string; total: number; done: number; progress: number }>;
+      };
+      expect(spacesResponse.status).toBe(200);
+      expect(spacesBody.ok).toBe(true);
+      const frontend = spacesBody.spaces.find((space) => space.name === 'spaces/frontend.md');
+      expect(frontend).toBeTruthy();
+      expect(frontend).toMatchObject({
+        total: 1,
+        done: 1,
+        progress: 100,
+      });
+
+      const timelineResponse = await fetch(`${handle.baseUrl}/api/lens/timeline?space=spaces/infrastructure.md`);
+      const timelineBody = await timelineResponse.json() as {
+        ok: boolean;
+        events: Array<{ actor: string; operation: string; threadTitle?: string; changedFields: Record<string, unknown> }>;
+      };
+      expect(timelineResponse.status).toBe(200);
+      expect(timelineBody.ok).toBe(true);
+      expect(timelineBody.events.length).toBeGreaterThan(0);
+      expect(
+        timelineBody.events.some((event) =>
+          event.operation === 'block' &&
+          event.threadTitle === 'Infra blocked' &&
+          event.changedFields.status === 'blocked',
+        ),
+      ).toBe(true);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('registers/lists/deletes webhooks and dispatches signed matching events', async () => {
+    const capture = await startWebhookCaptureServer();
+    const handle = await startWorkgraphServer({
+      workspacePath,
+      host: '127.0.0.1',
+      port: 0,
+    });
+    try {
+      const registerResponse = await fetch(`${handle.baseUrl}/api/webhooks`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          url: capture.url,
+          events: ['thread.*'],
+          secret: 'top-secret',
+        }),
+      });
+      const registerBody = await registerResponse.json() as {
+        ok: boolean;
+        webhook: { id: string; hasSecret: boolean };
+      };
+      expect(registerResponse.status).toBe(201);
+      expect(registerBody.ok).toBe(true);
+      expect(registerBody.webhook.hasSecret).toBe(true);
+
+      const listResponse = await fetch(`${handle.baseUrl}/api/webhooks`);
+      const listBody = await listResponse.json() as {
+        ok: boolean;
+        count: number;
+        webhooks: Array<{ id: string }>;
+      };
+      expect(listResponse.status).toBe(200);
+      expect(listBody.ok).toBe(true);
+      expect(listBody.count).toBe(1);
+      expect(listBody.webhooks[0].id).toBe(registerBody.webhook.id);
+
+      thread.createThread(workspacePath, 'Webhook thread', 'Send webhook event', 'agent-webhook');
+      await waitFor(() => capture.received.length >= 1);
+      const dispatched = capture.received[0];
+      expect(dispatched.body).toContain('"type":"thread.created"');
+      const expectedSignature = `sha256=${crypto.createHmac('sha256', 'top-secret').update(dispatched.body).digest('hex')}`;
+      expect(dispatched.headers['x-workgraph-signature']).toBe(expectedSignature);
+
+      const deleteResponse = await fetch(`${handle.baseUrl}/api/webhooks/${registerBody.webhook.id}`, {
+        method: 'DELETE',
+      });
+      expect(deleteResponse.status).toBe(200);
+
+      const countAfterDelete = capture.received.length;
+      thread.createThread(workspacePath, 'Webhook no dispatch', 'Should not dispatch', 'agent-webhook');
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(capture.received.length).toBe(countAfterDelete);
+    } finally {
+      await handle.close();
+      await capture.close();
+    }
+  });
+});
+
+async function connectSse(
+  url: string,
+  headers: Record<string, string> = {},
+): Promise<{
+  text: () => string;
+  close: () => void;
+}> {
+  const chunks: string[] = [];
+  const request = http.request(url, {
+    method: 'GET',
+    headers,
+  });
+  request.end();
+
+  const response = await new Promise<http.IncomingMessage>((resolve, reject) => {
+    request.once('response', resolve);
+    request.once('error', reject);
+  });
+  response.setEncoding('utf8');
+  response.on('data', (chunk: string) => {
+    chunks.push(chunk);
+  });
+
+  return {
+    text: () => chunks.join(''),
+    close: () => {
+      request.destroy();
+      response.destroy();
+    },
+  };
+}
+
+async function startWebhookCaptureServer(): Promise<{
+  url: string;
+  received: Array<{ headers: http.IncomingHttpHeaders; body: string }>;
+  close: () => Promise<void>;
+}> {
+  const received: Array<{ headers: http.IncomingHttpHeaders; body: string }> = [];
+  const server = http.createServer((req, res) => {
+    const bodyChunks: Buffer[] = [];
+    req.on('data', (chunk) => bodyChunks.push(Buffer.from(chunk)));
+    req.on('end', () => {
+      received.push({
+        headers: req.headers,
+        body: Buffer.concat(bodyChunks).toString('utf8'),
+      });
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ ok: true }));
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to start webhook capture server.');
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}/webhook`,
+    received,
+    close: async () => {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    },
+  };
+}
+
+function setThreadUpdatedTimestamp(workspaceRoot: string, threadPath: string, timestamp: string): void {
+  const absolutePath = path.join(workspaceRoot, threadPath);
+  const parsed = matter(fs.readFileSync(absolutePath, 'utf8'));
+  const nextData = {
+    ...(parsed.data as Record<string, unknown>),
+    updated: timestamp,
+  };
+  fs.writeFileSync(absolutePath, matter.stringify(parsed.content, nextData), 'utf8');
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error('Timed out waiting for condition');
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add SSE event stream, smart lens endpoints, and webhook dispatch to the WorkGraph server to enable a reactive, self-organizing dashboard.

---
<p><a href="https://cursor.com/agents/bc-f11076e8-0020-49e9-ba1e-af01b4235813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f11076e8-0020-49e9-ba1e-af01b4235813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->